### PR TITLE
Correct hashie version dependency for compatibility with hashie 3

### DIFF
--- a/vkontakte_api.gemspec
+++ b/vkontakte_api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday_middleware',          '~> 0.9.1'
   s.add_runtime_dependency 'faraday_middleware-parse_oj', '~> 0.3'
   s.add_runtime_dependency 'oauth2',                      '~> 0.8'
-  s.add_runtime_dependency 'hashie',                      '~> 2.0'
+  s.add_runtime_dependency 'hashie',                      '>= 2.0'
   
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14'


### PR DESCRIPTION
Some gems(for example omniauth (~> 1.2) ) depends on hashie 3.1.0 now and so there is an error while bundle resolving dependencies.
