### PR TITLE
Уточнение о использовании retry в README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ VkontakteApi.configure do |config|
     }
   }
   # максимальное количество повторов запроса при ошибках
+  # работает только если переключить http_verb в :get
   config.max_retries = 2
   
   # логгер


### PR DESCRIPTION
В стандартной конфигурации max_retries не работает, т.к. POST не является idempotent, и потому такие запросы по умолчанию [не повторяются в faraday](https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb#L88).

Если переключить http_verb на GET - retry начинает работать как и ожидается.