### PR TITLE
fix VkontakteApi::Error for internal server error

### DIFF
--- a/lib/vkontakte_api/error.rb
+++ b/lib/vkontakte_api/error.rb
@@ -23,7 +23,7 @@ module VkontakteApi
       @error_code = data.error_code
       @error_msg  = data.error_msg
       
-      request_params = parse_params(data.request_params)
+      request_params = data.request_params ? parse_params(data.request_params) : {}
       
       @method_name  = request_params.delete('method')
       @access_token = request_params.delete('access_token')

--- a/spec/vkontakte_api/error_spec.rb
+++ b/spec/vkontakte_api/error_spec.rb
@@ -51,5 +51,19 @@ describe VkontakteApi::Error do
         }.to raise_error(error.class, message)
       end
     end
+
+    context "for interval server error without request_params" do
+      let(:error) { VkontakteApi::Error.new(Hashie::Mash.new(error_code: 11, error_msg: 'Internal server error: Unknown error, try later')) }
+
+      it "returns all needed data about an error" do
+        message = 'VKontakte returned an error 11: \'Internal server error: Unknown error, try later\''
+        message << ' after calling method \'\' without parameters.'
+
+        expect {
+          raise error
+        }.to raise_error(error.class, message)
+      end
+    end
   end
 end
+


### PR DESCRIPTION
Здравствуйте.
При вызове метода execute бывает от сервера получаю вот такой ответ
{"error": {"error_code": 10,"error_msg": "Internal server error: Unknown error, try later"}}

так как в данном ответе нету поля request_params, то парсинг ошибки валится.
Вот часть backtrace подобной ситуации:

"/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/error.rb:55:in `parse_params'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/error.rb:26:in `initialize'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/result.rb:31:in `new'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/result.rb:31:in `extract_result'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/result.rb:14:in `process'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/method.rb:14:in `call'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/resolver.rb:20:in `call_method'", "/home/konstantin/projects/olivea-production/shared/bundle/ruby/2.3.0/gems/vkontakte_api-1.4.4/lib/vkontakte_api/client.rb:88:in `execute'".....
