### PR TITLE
add raise for execute_errors

### DIFF
--- a/lib/vkontakte_api/result.rb
+++ b/lib/vkontakte_api/result.rb
@@ -29,6 +29,10 @@ module VkontakteApi
       def extract_result(response)
         if response.error?
           raise VkontakteApi::Error.new(response.error)
+        elsif response.execute_errors?
+          error = response.execute_errors.last
+          error.method = response.execute_errors.map{ |er| er['method'] }.reverse.join ' -> '
+          raise VkontakteApi::Error.new(error)
         else
           response.response
         end

--- a/spec/vkontakte_api/result_spec.rb
+++ b/spec/vkontakte_api/result_spec.rb
@@ -80,6 +80,16 @@ describe VkontakteApi::Result do
         ]
       }
     end
+
+    let(:response_error_for_execute) do
+      {
+        'response'=>'', 
+        'execute_errors'=>[
+          {'method'=>'groups.getMembers', 'error_code'=>15, 'error_msg'=>'Access denied: you should be group moderator'}, 
+          {'method'=>'execute', 'error_code'=>15, 'error_msg'=>'Access denied: you should be group moderator'}
+        ]
+      }
+    end
     
     context "with a successful response" do
       let(:result) { Hashie::Mash.new(response: result_response) }
@@ -92,6 +102,16 @@ describe VkontakteApi::Result do
     context "with an error response" do
       let(:result) { Hashie::Mash.new(error: result_error) }
       
+      it "raises a VkontakteApi::Error" do
+        expect {
+          subject.send(:extract_result, result)
+        }.to raise_error(VkontakteApi::Error)
+      end
+    end
+
+    context "with an error response for execute method" do
+      let(:result) { Hashie::Mash.new(response_error_for_execute) }
+
       it "raises a VkontakteApi::Error" do
         expect {
           subject.send(:extract_result, result)


### PR DESCRIPTION
Здравствуйте.

При вызове метода execute возвращается ответ вот такого типа:  
{"response":"","execute_errors":[{"method":"groups.getMembers","error_code":15,"error_msg":"Access denied: you should be group moderator"},{"method":"execute","error_code":15,"error_msg":"Access denied: you should be group moderator"}]

Так как при разборе ответа идет проверка на присутствие поля error, то данный ответ не считается ошибкой и приложение не выбрасывает VkontakteApi::Error и пытается обработать результат.

Данная проблема уже подымалась вот тут https://github.com/7even/vkontakte_api/pull/43
Но данный пул реквест уже давно висит открытым + в нем предлагается ввести еще один тип ошибок VkontakteApi::ExecuteError.

Я предлагаю выбрасывать стандартный ексепшин VkontakteApi::Error просто в поле method отобразить цыпочку вызовов "execute -> groups.getMembers", так как поля error_code, error_msg просто дублируются.